### PR TITLE
refactor: shift Room Playlist ownership from TuneIn Spotify account to room owner's

### DIFF
--- a/backend/src/auth/spotify/spotifyauth.service.ts
+++ b/backend/src/auth/spotify/spotifyauth.service.ts
@@ -84,7 +84,7 @@ export class SpotifyAuthService {
 	private clientSecret: string;
 	// private redirectUri: string;
 	private authHeader: string;
-	private selfAuthorisedAPI: Spotify.SpotifyApi;
+	// private selfAuthorisedAPI: Spotify.SpotifyApi;
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -117,10 +117,10 @@ export class SpotifyAuthService {
 			`${this.clientId}:${this.clientSecret}`,
 		).toString("base64");
 
-		this.selfAuthorisedAPI = Spotify.SpotifyApi.withClientCredentials(
-			this.clientId,
-			this.clientSecret,
-		);
+		// this.selfAuthorisedAPI = Spotify.SpotifyApi.withClientCredentials(
+		// 	this.clientId,
+		// 	this.clientSecret,
+		// );
 	}
 
 	//how state is constructed in frontend
@@ -426,10 +426,6 @@ export class SpotifyAuthService {
 			await this.saveUserSpotifyTokens(newPair, userID);
 			return newPair;
 		}
-		return JSON.parse(tokens.token) as SpotifyTokenPair;
-	}
-
-	getUserlessAPI(): Spotify.SpotifyApi {
-		return this.selfAuthorisedAPI;
+		return tk;
 	}
 }

--- a/backend/src/auth/spotify/spotifyauth.service.ts
+++ b/backend/src/auth/spotify/spotifyauth.service.ts
@@ -377,6 +377,7 @@ export class SpotifyAuthService {
 	async saveUserSpotifyTokens(tk: SpotifyTokenPair, userID: string) {
 		const user = await this.prisma.users.findFirst({
 			where: { user_id: userID },
+			include: { authentication: true },
 		});
 
 		if (!user) {
@@ -384,18 +385,7 @@ export class SpotifyAuthService {
 		}
 
 		try {
-			const existingTokens: PrismaTypes.authentication[] | null =
-				await this.prisma.authentication.findMany({
-					where: { user_id: user.user_id },
-				});
-
-			if (!existingTokens || existingTokens === null) {
-				throw new Error(
-					"A database error occurred while checking if the user's tokens exist",
-				);
-			}
-
-			if (existingTokens.length > 0) {
+			if (user.authentication !== null) {
 				await this.prisma.authentication.update({
 					where: { user_id: user.user_id },
 					data: {

--- a/backend/src/modules/rooms/roomqueue/roomqueue.service.ts
+++ b/backend/src/modules/rooms/roomqueue/roomqueue.service.ts
@@ -853,7 +853,7 @@ export class ActiveRoom {
 		);
 		await this.updateQueue(murLockService);
 		await spotify.addSongsToRoomPlaylist(
-			this.room.spotifyPlaylistID,
+			this.room,
 			songs.map((s) => s.spotifyID),
 		);
 		return result;
@@ -928,7 +928,7 @@ export class ActiveRoom {
 			}
 		}
 		await spotify.replaceSongsFromRoomPlaylist(
-			this.room.spotifyPlaylistID,
+			this.room,
 			i,
 			roomSongs.slice(i).map((s) => s.spotifyID),
 		);

--- a/frontend/app/screens/WelcomeScreen.tsx
+++ b/frontend/app/screens/WelcomeScreen.tsx
@@ -88,7 +88,7 @@ const WelcomeScreen: React.FC = () => {
 			state: state,
 			extraParams: {
 				// use the "show_dialog" parameter to force the user to approve the app again
-				show_dialog: true,
+				show_dialog: "true",
 			},
 		},
 		discovery,


### PR DESCRIPTION
## Description
For each room there exists a Spotify playlist containing every song that has played or is enqueued to play.
Playlists for every room would be created and owned by our own TuneIn account and then modified in the backend,
this changes the ownership to the room owner and refactors accordingly.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other: (summarise briefly here)

## Changes Made
I also cleared out every previous Playlist ID in the database as they are now defunct and not consistent with app behaviour.

## Does this break anything? (Modifying more expected behaviour/layout, etc)
- [ ] Yes
- [x] No

## Checklist
- [x] I have tested this code locally
- [x] I have reviewed the code for readability and maintainability
- [x] I have added appropriate documentation or updated existing documentation
- [x] I have ensured that my changes follow the project's coding conventions
- [ ] I have performed additional steps, if required [e.g., database migrations, configuration changes, etc.]

## Additional Notes
[Include any additional notes or context relevant to the pull request]

## (ignore) A checklist for the reviewer to use
```
## Reviewer Checklist
- [ ] Code quality and readability
- [ ] Adequate documentation
- [ ] Follows project coding conventions
- [ ] Considered security implications
- [ ] Considered accessibility implications
- [ ] Considered performance implications
- [ ] Tested locally
```